### PR TITLE
fix(main): read app version dynamically in About dialog

### DIFF
--- a/main.js
+++ b/main.js
@@ -245,7 +245,7 @@ function buildMenu() {
               type: 'info',
               title: '关于',
               message: 'Slide X',
-              detail: 'Version 1.0.0\nAI-powered presentation editor'
+              detail: `Version ${app.getVersion()}\nAI-powered presentation editor`
             })
           }
         }


### PR DESCRIPTION
## Summary

- Replace hardcoded `"Version 1.0.0"` in the About dialog with `app.getVersion()`, which reads the `version` field from `package.json` at runtime

## Problem

The About dialog hardcoded the version string:

```js
detail: "Version 1.0.0\nAI-powered presentation editor"
```

After any release that bumps `package.json` version, this string would silently go stale unless manually updated — a common source of version drift.

## Fix

```js
detail: `Version ${app.getVersion()}\nAI-powered presentation editor`
```

`app.getVersion()` is an Electron API that returns the version from `package.json` (or the platform app version in packaged builds), so it always stays in sync.

## Test plan

- [ ] Open Help → 关于 Slide X and verify the version matches `package.json`
- [ ] Bump `package.json` version and confirm the dialog reflects the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)